### PR TITLE
Added a link to the French standards body

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@
 - [BS](https://www.bsigroup.com/) - **British Standards**: Standards published by the BSI Group, the UK's National Standards Body (NSB). They provide guidelines for quality, safety, and sustainability across various sectors.
 - [CEN](https://www.cencenelec.eu/) - **European Committee for Standardization**: Develops European Standards (ENs) to harmonize technical specifications and promote trade across Europe.
 - [DIN](https://www.din.de/) - **Deutsches Institut für Normung**: German Institute for Standardization, which develops national and international standards for a wide range of industries.
-- [AFNOR](https://www.afnor.org/) - **Association française de normalisation**: France's National Standardization Office 
+- [AFNOR](https://www.afnor.org/) - **Association française de normalisation**: France's National Standardization Office.
 - [NSAI](https://www.nsai.ie/) - **National Standards Authority of Ireland**: Ireland's official standards body.
 - [CSA Group](https://www.csagroup.org/) - **Canadian Standards Association**: Develops standards to address safety, sustainability, and performance for Canada and global markets.
 - [SII](https://www.sii.org.il/eng/) - **Standards Institution of Israel**: National body for standards and certification.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - [BS](https://www.bsigroup.com/) - **British Standards**: Standards published by the BSI Group, the UK's National Standards Body (NSB). They provide guidelines for quality, safety, and sustainability across various sectors.
 - [CEN](https://www.cencenelec.eu/) - **European Committee for Standardization**: Develops European Standards (ENs) to harmonize technical specifications and promote trade across Europe.
 - [DIN](https://www.din.de/) - **Deutsches Institut für Normung**: German Institute for Standardization, which develops national and international standards for a wide range of industries.
+- [AFNOR](https://www.afnor.org/) - **Association française de normalisation**: France's National Standardization Office 
 - [NSAI](https://www.nsai.ie/) - **National Standards Authority of Ireland**: Ireland's official standards body.
 - [CSA Group](https://www.csagroup.org/) - **Canadian Standards Association**: Develops standards to address safety, sustainability, and performance for Canada and global markets.
 - [SII](https://www.sii.org.il/eng/) - **Standards Institution of Israel**: National body for standards and certification.


### PR DESCRIPTION
Added an entry to the list of standardization bodies for  AFNOR (Association française de normalisation) the French standards body

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/donBarbos/awesome-standards/pull/1?shareId=1dd63548-a71a-41c6-8b22-57753e31e1df).