### PR TITLE
Add Hiero Consensus Standards (HCS) to Decentralized Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [CAIPs](https://github.com/ChainAgnostic/CAIPs) - Chain Agnostic Improvement Proposals.
 - [AIPs](https://governance.aptosfoundation.org/) - Aptos Improvement Proposals.
 - [HIPs](https://github.com/helium/HIP) - Helium Improvement Proposals.
+- [HCS](https://github.com/hiero-ledger/hiero-consensus-specifications) - Hiero Consensus Standards for interoperable data formats and protocols on the Hiero network, covering file storage, registries, NFT inscriptions (Hashinals), AI agent communication, and more.
 - [MIPs](https://github.com/makerdao/mips) - Maker Improvement Proposals.
 - [SNIPs](https://github.com/starknet-io/SNIPs) - Starknet Improvement Proposals.
 - [Nervos Network RFCs](https://github.com/nervosnetwork/rfcs) - Proposals, standards and documentations related to Nervos Network.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@
 - [CAIPs](https://github.com/ChainAgnostic/CAIPs) - Chain Agnostic Improvement Proposals.
 - [AIPs](https://governance.aptosfoundation.org/) - Aptos Improvement Proposals.
 - [HIPs](https://github.com/helium/HIP) - Helium Improvement Proposals.
-- [HCS](https://github.com/hiero-ledger/hiero-consensus-specifications) - Hiero Consensus Standards for interoperable data formats and protocols on the Hiero network, covering file storage, registries, NFT inscriptions (Hashinals), AI agent communication, and more.
+- [HCS](https://github.com/hiero-ledger/hiero-consensus-specifications) - Hiero Consensus Standards.
 - [MIPs](https://github.com/makerdao/mips) - Maker Improvement Proposals.
 - [SNIPs](https://github.com/starknet-io/SNIPs) - Starknet Improvement Proposals.
 - [Nervos Network RFCs](https://github.com/nervosnetwork/rfcs) - Proposals, standards and documentations related to Nervos Network.


### PR DESCRIPTION
Adding Hiero Consensus Standards (HCS) to the Decentralized Systems section.

## What is HCS?

Hiero Consensus Standards are open, versioned specifications for interoperable data formats and protocol patterns built on top of the Hiero Consensus Service. They define standards for:

- **HCS-1**: File management (encode, chunk, upload, retrieve files)
- **HCS-2**: Topic registries for structured data organization
- **HCS-5/6/7**: Hashinals (NFT inscriptions similar to Ordinals)
- **HCS-10**: AI agent communication and discovery
- **HCS-11**: Profile metadata for identity management
- **HCS-13**: Schema registries for validation
- And more (20+ standards total)

## Why it belongs here

Similar to BIPs (Bitcoin), EIPs (Ethereum), and other blockchain improvement proposals listed in this section, HCS provides formal specifications for building interoperable applications on the Hiero distributed ledger network.

The repository is maintained under the Linux Foundation's Hiero project and was originally created by Hashgraph Online.

## Links
- Repository: https://github.com/hiero-ledger/hiero-consensus-specifications
- Documentation: https://hol.org/docs/standards/
- Reference Implementation: https://hol.org/docs/libraries/standards-sdk/overview

Thanks for maintaining this resource!